### PR TITLE
Add gbtgui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+gbtgui/gbtgui
 .DS_Store
 garbage/

--- a/gbtgui/go.mod
+++ b/gbtgui/go.mod
@@ -1,0 +1,5 @@
+module gbtgui
+
+go 1.22.2
+
+require github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e

--- a/gbtgui/go.mod
+++ b/gbtgui/go.mod
@@ -2,4 +2,7 @@ module gbtgui
 
 go 1.22.2
 
-require github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e
+require (
+	github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e
+	github.com/brandondube/tai v0.1.0
+)

--- a/gbtgui/go.sum
+++ b/gbtgui/go.sum
@@ -1,0 +1,2 @@
+github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e h1:wSQCJiig/QkoUnpvelSPbLiZNWvh2yMqQTQvIQqSUkU=
+github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e/go.mod h1:5G2EjwzgZUPnnReoKvPWVneT8APYbyKkihDVAHUi0II=

--- a/gbtgui/go.sum
+++ b/gbtgui/go.sum
@@ -1,2 +1,4 @@
 github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e h1:wSQCJiig/QkoUnpvelSPbLiZNWvh2yMqQTQvIQqSUkU=
 github.com/andlabs/ui v0.0.0-20200610043537-70a69d6ae31e/go.mod h1:5G2EjwzgZUPnnReoKvPWVneT8APYbyKkihDVAHUi0II=
+github.com/brandondube/tai v0.1.0 h1:psVhcG48XNq1LtQtvz6C5+6JU+n1UFjE9XeYLLDJ/cs=
+github.com/brandondube/tai v0.1.0/go.mod h1:Zx9tLMhTfJhSns4czs9WIs8wPR5oT2OuJNDhGR/GHgw=

--- a/gbtgui/main.go
+++ b/gbtgui/main.go
@@ -27,9 +27,8 @@ import (
 	"time"
 
 	"github.com/andlabs/ui"
+	"github.com/brandondube/tai"
 )
-
-var leapSeconds int = 37
 
 func main() {
 	err := ui.Main(func() {
@@ -63,12 +62,11 @@ func main() {
 }
 
 func timeInTaiString(local time.Time) string {
-	utc := local.UTC()
-
-	hourSeconds := utc.Hour() * 3600
-	minuteSeconds := utc.Minute() * 60
-	seconds := utc.Second()
-	beatTai := float64((hourSeconds + minuteSeconds + seconds + leapSeconds)) / 86.4
+	g := tai.FromTime(local).AsGregorian()
+	hourSeconds := g.Hour * 3600
+	minuteSeconds := g.Min * 60
+	seconds := g.Sec
+	beatTai := float64(hourSeconds+minuteSeconds+seconds) / 86.4
 
 	return fmt.Sprintf("@%06.2f (%02d:%02d:%02d)", beatTai, local.Hour(), local.Minute(), local.Second())
 }

--- a/gbtgui/main.go
+++ b/gbtgui/main.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2014 Peter Hellberg (http://c7.se/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+// OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// To build this on Debian and Ubuntu, install libgtk-3-dev first.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/andlabs/ui"
+)
+
+var leapSeconds int = 37
+
+func main() {
+	err := ui.Main(func() {
+		w := ui.NewWindow("beatTAI GUI", 205, 24, false)
+		w.SetMargined(true)
+
+		l := ui.NewLabel("")
+		w.SetChild(l)
+
+		w.OnClosing(func(*ui.Window) bool {
+			ui.Quit()
+			return true
+		})
+
+		go func() {
+			ticker := time.NewTicker(500 * time.Millisecond)
+			defer ticker.Stop()
+
+			for now := range ticker.C {
+				ui.QueueMain(func() {
+					l.SetText(timeInTaiString(now))
+				})
+			}
+		}()
+
+		w.Show()
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func timeInTaiString(local time.Time) string {
+	utc := local.UTC()
+
+	hourSeconds := utc.Hour() * 3600
+	minuteSeconds := utc.Minute() * 60
+	seconds := utc.Second()
+	beatTai := float64((hourSeconds + minuteSeconds + seconds + leapSeconds)) / 86.4
+
+	return fmt.Sprintf("@%06.2f (%02d:%02d:%02d)", beatTai, local.Hour(), local.Minute(), local.Second())
+}


### PR DESCRIPTION
Presented for your consideration, this PR adds a GUI modified from [github.com/peterhellberg/beats/cmd/beats-gui](https://github.com/peterhellberg/beats/tree/272a6adeb59b82fee6f33a67f48cf36b99d854e2/cmd/beats-gui) to display beatTAI along with the local time.

<p><img alt="beatTAI GUI screenshot." src="https://github.com/user-attachments/assets/815f9e67-585c-4fcc-b8b1-7d1ec774a84e" width="243"></p>

The code is MIT rather than Unlicense, if it matters, because that is the license of the original code. If you wouldn't mind a GUI but want to keep this repo under Unlicense, I can write a replacement.

I like the idea of International Atomic Internet Time.