### PR TITLE
Use TAI library to not hard-code leap seconds in Go

### DIFF
--- a/gbt/gbt.go
+++ b/gbt/gbt.go
@@ -1,30 +1,30 @@
 package main
 
 import (
-   "fmt"
-   "time"
+	"fmt"
+	"time"
 )
 
 func main() {
-   // variable to store the number of leap seconds. this is really lazy but
-   // later I'll find a way to snag the current number of leap seconds, until
-   // then this will need to be manually changed any time a new leap second is
-   // added.
-   leapSeconds := 37
+	// variable to store the number of leap seconds. this is really lazy but
+	// later I'll find a way to snag the current number of leap seconds, until
+	// then this will need to be manually changed any time a new leap second is
+	// added.
+	leapSeconds := 37
 
-   // grab the current time in UTC
-   currentTime := time.Now().UTC()
+	// grab the current time in UTC
+	currentTime := time.Now().UTC()
 
-   // pull the hour, minute, and second from the current time and convert the
-   // hour and minute to seconds
-   hourSeconds := currentTime.Hour() * 3600
-   minuteSeconds := currentTime.Minute() * 60
-   seconds := currentTime.Second()
+	// pull the hour, minute, and second from the current time and convert the
+	// hour and minute to seconds
+	hourSeconds := currentTime.Hour() * 3600
+	minuteSeconds := currentTime.Minute() * 60
+	seconds := currentTime.Second()
 
-   // do the math for beatTAI and store it
-   beatTAI := float64((hourSeconds + minuteSeconds + seconds + leapSeconds)) / 86.4
+	// do the math for beatTAI and store it
+	beatTAI := float64((hourSeconds + minuteSeconds + seconds + leapSeconds)) / 86.4
 
-   // print the value, rounded to two decimal places, padded with leading zeroes
-   // if necessary and prefixed with : for proper beatTAI syntax
-   fmt.Printf(":%06.2f\n", beatTAI)
+	// print the value, rounded to two decimal places, padded with leading zeroes
+	// if necessary and prefixed with : for proper beatTAI syntax
+	fmt.Printf(":%06.2f\n", beatTAI)
 }

--- a/gbt/gbt.go
+++ b/gbt/gbt.go
@@ -2,27 +2,21 @@ package main
 
 import (
 	"fmt"
-	"time"
+
+	"github.com/brandondube/tai"
 )
 
 func main() {
-	// variable to store the number of leap seconds. this is really lazy but
-	// later I'll find a way to snag the current number of leap seconds, until
-	// then this will need to be manually changed any time a new leap second is
-	// added.
-	leapSeconds := 37
+	g := tai.Now().AsGregorian()
 
-	// grab the current time in UTC
-	currentTime := time.Now().UTC()
-
-	// pull the hour, minute, and second from the current time and convert the
+	// pull the hour, minute, and second from the TAI time and convert the
 	// hour and minute to seconds
-	hourSeconds := currentTime.Hour() * 3600
-	minuteSeconds := currentTime.Minute() * 60
-	seconds := currentTime.Second()
+	hourSeconds := g.Hour * 3600
+	minuteSeconds := g.Min * 60
+	seconds := g.Sec
 
 	// do the math for beatTAI and store it
-	beatTAI := float64((hourSeconds + minuteSeconds + seconds + leapSeconds)) / 86.4
+	beatTAI := float64(hourSeconds+minuteSeconds+seconds) / 86.4
 
 	// print the value, rounded to two decimal places, padded with leading zeroes
 	// if necessary and prefixed with : for proper beatTAI syntax

--- a/gbt/go.mod
+++ b/gbt/go.mod
@@ -1,3 +1,5 @@
 module gbt
 
 go 1.20
+
+require github.com/brandondube/tai v0.1.0

--- a/gbt/go.sum
+++ b/gbt/go.sum
@@ -1,0 +1,2 @@
+github.com/brandondube/tai v0.1.0 h1:psVhcG48XNq1LtQtvz6C5+6JU+n1UFjE9XeYLLDJ/cs=
+github.com/brandondube/tai v0.1.0/go.mod h1:Zx9tLMhTfJhSns4czs9WIs8wPR5oT2OuJNDhGR/GHgw=


### PR DESCRIPTION
The library is [github.com/brandondube/tai](https://github.com/brandondube/tai).